### PR TITLE
Add ability to vary number of cores stressed and make idle duration configurable

### DIFF
--- a/stressberry/cli.py
+++ b/stressberry/cli.py
@@ -50,8 +50,15 @@ def _get_parser_run():
         "-d",
         "--duration",
         type=int,
-        default=600,
-        help="test duration in seconds (default: 600)",
+        default=300,
+        help="stress test duration in seconds (default: 300)",
+    )
+    parser.add_argument(
+        "-i",
+        "--idle",
+        type=int,
+        default=150,
+        help="idle time in seconds at start and end of stress test (default: 150)",
     )
     parser.add_argument(
         "-c",
@@ -69,11 +76,14 @@ def run(argv=None):
     args = parser.parse_args(argv)
 
     # Cool down first
-    print("Cooldown...")
+    print("Awaiting stable baseline temperature...")
     cooldown(filename=args.temperature_file)
 
     # Start the stress test in another thread
-    t = threading.Thread(target=lambda: test(args.duration, args.cores), args=())
+    t = threading.Thread(
+        target=lambda: test(args.duration, args.idle, args.cores),
+        args=()
+    )
     t.start()
 
     times = []

--- a/stressberry/cli.py
+++ b/stressberry/cli.py
@@ -53,6 +53,13 @@ def _get_parser_run():
         default=600,
         help="test duration in seconds (default: 600)",
     )
+    parser.add_argument(
+        "-c",
+        "--cores",
+        type=int,
+        default=None,
+        help="number of cpu cores to stress (default: all)",
+    )
     parser.add_argument("outfile", type=argparse.FileType("w"), help="output data file")
     return parser
 
@@ -66,7 +73,7 @@ def run(argv=None):
     cooldown(filename=args.temperature_file)
 
     # Start the stress test in another thread
-    t = threading.Thread(target=lambda: test(args.duration), args=())
+    t = threading.Thread(target=lambda: test(args.duration, args.cores), args=())
     t.start()
 
     times = []

--- a/stressberry/main.py
+++ b/stressberry/main.py
@@ -1,5 +1,6 @@
 import subprocess
 import time as tme
+from os import cpu_count
 
 
 def stress_cpu(num_cpus, time):
@@ -35,10 +36,28 @@ def measure_temp(filename="/sys/class/thermal/thermal_zone0/temp"):
     return temp
 
 
-def test(duration):
-    print("Idling...")
-    tme.sleep(0.25 * duration)
-    stress_cpu(4, time=0.5 * duration)
-    print("Idling...")
-    tme.sleep(0.25 * duration)
+def cpu_core_count():
+    """Returns the number of CPU cores
+    """
+    count = cpu_count()
+    return count
+
+
+def test(duration, cores):
+    """Run stress test with 25% of test duration for idle before and after the stres
+    """
+    stress_duration = 0.5 * duration
+    idle_duration = 0.25 * duration
+
+    if cores is None:
+        cores = cpu_core_count()
+
+    print("Preparing to stress: [{}] CPU Cores for [{}] seconds".format(cores, stress_duration))
+    print("Idling for {} seconds...".format(idle_duration))
+    tme.sleep(idle_duration)
+
+    stress_cpu(num_cpus=cores, time=stress_duration)
+
+    print("Idling for {} seconds...".format(idle_duration))
+    tme.sleep(idle_duration)
     return

--- a/stressberry/main.py
+++ b/stressberry/main.py
@@ -43,12 +43,9 @@ def cpu_core_count():
     return count
 
 
-def test(duration, cores):
+def test(stress_duration, idle_duration, cores):
     """Run stress test with 25% of test duration for idle before and after the stres
     """
-    stress_duration = 0.5 * duration
-    idle_duration = 0.25 * duration
-
     if cores is None:
         cores = cpu_core_count()
 

--- a/stressberry/main.py
+++ b/stressberry/main.py
@@ -44,7 +44,8 @@ def cpu_core_count():
 
 
 def test(stress_duration, idle_duration, cores):
-    """Run stress test with 25% of test duration for idle before and after the stres
+    """Run stress test for specified duration with specified idle times
+       at the start and end of the test.
     """
     if cores is None:
         cores = cpu_core_count()


### PR DESCRIPTION
Add the ability to run 'stress' on a subset of cores via command-line argument.
Change default test to use all cores, rather than hardcoded to 4. (Pi Zero only has a single core).
Add ability to make idle time configurable, as 25% is too long for longer running stress tests. This does change the meaning of duration in the command line, to be the actual stress test part. Existing default overall duration is maintained new defaults for the duration and idle time.