### PR TITLE
Add ability to vary number of cores stressed

### DIFF
--- a/stressberry/cli.py
+++ b/stressberry/cli.py
@@ -53,6 +53,13 @@ def _get_parser_run():
         default=600,
         help="test duration in seconds (default: 600)",
     )
+    parser.add_argument(
+        "-c",
+        "--cores",
+        type=int,
+        default=None,
+        help="number of cpu cores to stress (default: all)",
+    )
     parser.add_argument("outfile", type=argparse.FileType("w"), help="output data file")
     return parser
 
@@ -66,7 +73,7 @@ def run(argv=None):
     cooldown(filename=args.temperature_file)
 
     # Start the stress test in another thread
-    t = threading.Thread(target=lambda: test(args.duration), args=())
+    t = threading.Thread(target=lambda: test(args.duration, args.cores), args=())
     t.start()
 
     times = []

--- a/stressberry/main.py
+++ b/stressberry/main.py
@@ -52,12 +52,12 @@ def test(duration, cores):
     if cores is None:
         cores = cpu_core_count()
 
-    print(f"Preparing to stress: [{cores}] CPU Cores for [{stress_duration}] seconds")
-    print(f"Idling for {idle_duration} seconds...")
+    print("Preparing to stress: [{}] CPU Cores for [{}] seconds".format(cores, stress_duration))
+    print("Idling for {} seconds...".format(idle_duration))
     tme.sleep(idle_duration)
 
     stress_cpu(num_cpus=cores, time=stress_duration)
 
-    print(f"Idling for {idle_duration} seconds...")
+    print("Idling for {} seconds...".format(idle_duration))
     tme.sleep(idle_duration)
     return

--- a/stressberry/main.py
+++ b/stressberry/main.py
@@ -36,13 +36,6 @@ def measure_temp(filename="/sys/class/thermal/thermal_zone0/temp"):
     return temp
 
 
-def cpu_core_count():
-    """Returns the number of CPU cores
-    """
-    count = cpu_count()
-    return count
-
-
 def test(duration, cores):
     """Run stress test with 25% of test duration for idle before and after the stres
     """
@@ -50,7 +43,7 @@ def test(duration, cores):
     idle_duration = 0.25 * duration
 
     if cores is None:
-        cores = cpu_core_count()
+        cores = cpu_count()
 
     print("Preparing to stress: [{}] CPU Cores for [{}] seconds".format(cores, stress_duration))
     print("Idling for {} seconds...".format(idle_duration))

--- a/stressberry/main.py
+++ b/stressberry/main.py
@@ -45,7 +45,7 @@ def test(duration, cores):
     if cores is None:
         cores = cpu_count()
 
-    print("Preparing to stress: [{}] CPU Cores for [{}] seconds".format(cores, stress_duration))
+    print("Preparing to stress [{}] CPU Cores for [{}] seconds".format(cores, stress_duration))
     print("Idling for {} seconds...".format(idle_duration))
     tme.sleep(idle_duration)
 

--- a/stressberry/main.py
+++ b/stressberry/main.py
@@ -1,5 +1,6 @@
 import subprocess
 import time as tme
+from os import cpu_count
 
 
 def stress_cpu(num_cpus, time):
@@ -35,10 +36,28 @@ def measure_temp(filename="/sys/class/thermal/thermal_zone0/temp"):
     return temp
 
 
-def test(duration):
-    print("Idling...")
-    tme.sleep(0.25 * duration)
-    stress_cpu(4, time=0.5 * duration)
-    print("Idling...")
-    tme.sleep(0.25 * duration)
+def cpu_core_count():
+    """Returns the number of CPU cores
+    """
+    count = cpu_count()
+    return count
+
+
+def test(duration, cores):
+    """Run stress test with 25% of test duration for idle before and after the stres
+    """
+    stress_duration = 0.5 * duration
+    idle_duration = 0.25 * duration
+
+    if cores is None:
+        cores = cpu_core_count()
+
+    print(f"Preparing to stress: [{cores}] CPU Cores for [{stress_duration}] seconds")
+    print(f"Idling for {idle_duration} seconds...")
+    tme.sleep(idle_duration)
+
+    stress_cpu(num_cpus=cores, time=stress_duration)
+
+    print(f"Idling for {idle_duration} seconds...")
+    tme.sleep(idle_duration)
     return

--- a/stressberry/main.py
+++ b/stressberry/main.py
@@ -45,7 +45,11 @@ def test(duration, cores):
     if cores is None:
         cores = cpu_count()
 
-    print("Preparing to stress [{}] CPU Cores for [{}] seconds".format(cores, stress_duration))
+    print(
+        "Preparing to stress [{}] CPU Cores for [{}] seconds".format(
+            cores, stress_duration
+        )
+    )
     print("Idling for {} seconds...".format(idle_duration))
     tme.sleep(idle_duration)
 


### PR DESCRIPTION
Add the ability to run 'stress' on a subset of cores via command-line argument.
Change default test to use all cores, rather than hardcoded to 4. (Pi Zero only has a single core).