### PR TITLE
Add ability to record and plot core clock frequency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build/
 *.dat
 *.png
 .pytest_cache/
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,3 @@ build/
 *.dat
 *.png
 .pytest_cache/
-.vscode/

--- a/stressberry/cli.py
+++ b/stressberry/cli.py
@@ -71,17 +71,17 @@ def _get_parser_run():
         "--cores",
         type=int,
         default=None,
-        help="number of cpu cores to stress (default: all)",
+        help="number of CPU cores to stress (default: all)",
     )
     parser.add_argument(
-        "-f", "--frequency", help="measure cpu core frequency", action="store_true"
+        "-f", "--frequency", help="measure CPU core frequency", action="store_true"
     )
     parser.add_argument(
         "-ff",
         "--frequency-file",
         type=str,
         default="/sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq",
-        help="cpu core frequency file. Must be used in conjunction with --disable-vcgencmd if vcgencmd exists (default: /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq)",
+        help="CPU core frequency file. Must be used in conjunction with --disable-vcgencmd if vcgencmd exists (default: /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq)",
     )
     parser.add_argument(
         "--disable-vcgencmd",
@@ -155,7 +155,7 @@ def plot(argv=None):
     data = [yaml.load(f, Loader=yaml.SafeLoader) for f in args.infiles]
 
     # sort the data such that the data series with the lowest terminal
-    # temperature is plotted last (and appears int he legend last)
+    # temperature is plotted last (and appears in the legend last)
     terminal_temps = [d["temperature"][-1] for d in data]
     order = [i[0] for i in sorted(enumerate(terminal_temps), key=lambda x: x[1])]
     # actually plot it
@@ -183,7 +183,7 @@ def plot(argv=None):
                     color="C1",
                 )
         except KeyError():
-            print("Source data does not contain cpu frequency data.")
+            print("Source data does not contain CPU frequency data.")
 
     if args.outfile is not None:
         plt.savefig(args.outfile, transparent=True, bbox_inches="tight", dpi=args.dpi)
@@ -229,7 +229,7 @@ def _get_parser_plot():
     parser.add_argument(
         "-f",
         "--frequency",
-        help="plot cpu core frequency (single input files only)",
+        help="plot CPU core frequency (single input files only)",
         action="store_true",
     )
     return parser

--- a/stressberry/cli.py
+++ b/stressberry/cli.py
@@ -40,7 +40,11 @@ def _get_parser_run():
         help="name the data set (default: 'stressberry data')",
     )
     parser.add_argument(
-        "-t", "--temperature-file", type=str, default=None, help="temperature file."
+        "-t",
+        "--temperature-file",
+        type=str,
+        default=None,
+        help="temperature file e.g /sys/class/thermal/thermal_zone0/temp (default: vcgencmd)",
     )
     parser.add_argument(
         "-d",
@@ -74,7 +78,7 @@ def _get_parser_run():
         "--frequency-file",
         type=str,
         default=None,
-        help="CPU core frequency file.",
+        help="CPU core frequency file e.g. /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq (default: vcgencmd)",
     )
     parser.add_argument("outfile", type=argparse.FileType("w"), help="output data file")
     return parser

--- a/stressberry/cli.py
+++ b/stressberry/cli.py
@@ -50,8 +50,15 @@ def _get_parser_run():
         "-d",
         "--duration",
         type=int,
-        default=600,
-        help="test duration in seconds (default: 600)",
+        default=300,
+        help="stress test duration in seconds (default: 300)",
+    )
+    parser.add_argument(
+        "-i",
+        "--idle",
+        type=int,
+        default=150,
+        help="idle time in seconds at start and end of stress test (default: 150)",
     )
     parser.add_argument(
         "-c",
@@ -69,11 +76,14 @@ def run(argv=None):
     args = parser.parse_args(argv)
 
     # Cool down first
-    print("Cooldown...")
+    print("Awaiting stable baseline temperature...")
     cooldown(filename=args.temperature_file)
 
     # Start the stress test in another thread
-    t = threading.Thread(target=lambda: test(args.duration, args.cores), args=())
+    t = threading.Thread(
+        target=lambda: test(args.duration, args.idle, args.cores),
+        args=()
+    )
     t.start()
 
     times = []

--- a/stressberry/cli.py
+++ b/stressberry/cli.py
@@ -96,7 +96,7 @@ def run(argv=None):
         temps.append(measure_temp(args.temperature_file))
         freqs.append(measure_core_frequency(args.frequency_file))
         print(
-            "Current temperature: {:4.1f}°C - Frequency: {:4d}MHz".format(
+            "Current temperature: {:4.1f}°C - Frequency: {:4.0f}MHz".format(
                 temps[-1], freqs[-1]
             )
         )

--- a/stressberry/cli.py
+++ b/stressberry/cli.py
@@ -71,17 +71,17 @@ def _get_parser_run():
         "--cores",
         type=int,
         default=None,
-        help="number of CPU cores to stress (default: all)",
+        help="number of cpu cores to stress (default: all)",
     )
     parser.add_argument(
-        "-f", "--frequency", help="measure CPU core frequency", action="store_true"
+        "-f", "--frequency", help="measure cpu core frequency", action="store_true"
     )
     parser.add_argument(
         "-ff",
         "--frequency-file",
         type=str,
         default="/sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq",
-        help="CPU core frequency file. Must be used in conjunction with --disable-vcgencmd if vcgencmd exists (default: /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq)",
+        help="cpu core frequency file. Must be used in conjunction with --disable-vcgencmd if vcgencmd exists (default: /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq)",
     )
     parser.add_argument(
         "--disable-vcgencmd",
@@ -155,7 +155,7 @@ def plot(argv=None):
     data = [yaml.load(f, Loader=yaml.SafeLoader) for f in args.infiles]
 
     # sort the data such that the data series with the lowest terminal
-    # temperature is plotted last (and appears in the legend last)
+    # temperature is plotted last (and appears int he legend last)
     terminal_temps = [d["temperature"][-1] for d in data]
     order = [i[0] for i in sorted(enumerate(terminal_temps), key=lambda x: x[1])]
     # actually plot it
@@ -183,7 +183,7 @@ def plot(argv=None):
                     color="C1",
                 )
         except KeyError():
-            print("Source data does not contain CPU frequency data.")
+            print("Source data does not contain cpu frequency data.")
 
     if args.outfile is not None:
         plt.savefig(args.outfile, transparent=True, bbox_inches="tight", dpi=args.dpi)
@@ -229,7 +229,7 @@ def _get_parser_plot():
     parser.add_argument(
         "-f",
         "--frequency",
-        help="plot CPU core frequency (single input files only)",
+        help="plot cpu core frequency (single input files only)",
         action="store_true",
     )
     return parser

--- a/stressberry/cli.py
+++ b/stressberry/cli.py
@@ -244,8 +244,9 @@ def _get_parser_plot():
     )
     parser.add_argument("--hide-legend", help="do not draw legend", action="store_true")
     parser.add_argument(
-        "--transparent",
-        help="replace transparent background opaque",
+        "--not-transparent",
+        dest="transparent",
+        help="do not make images transparent",
         action="store_false",
         default=True,
     )

--- a/stressberry/cli.py
+++ b/stressberry/cli.py
@@ -71,17 +71,17 @@ def _get_parser_run():
         "--cores",
         type=int,
         default=None,
-        help="number of cpu cores to stress (default: all)",
+        help="number of CPU cores to stress (default: all)",
     )
     parser.add_argument(
-        "-f", "--frequency", help="measure cpu core frequency", action="store_true"
+        "-f", "--frequency", help="measure CPU core frequency", action="store_true"
     )
     parser.add_argument(
         "-ff",
         "--frequency-file",
         type=str,
         default="/sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq",
-        help="cpu core frequency file. Must be used in conjunction with --disable-vcgencmd if vcgencmd exists (default: /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq)",
+        help="CPU core frequency file. Must be used in conjunction with --disable-vcgencmd if vcgencmd exists (default: /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq)",
     )
     parser.add_argument(
         "--disable-vcgencmd",
@@ -118,11 +118,11 @@ def run(argv=None):
             freqs.append(measure_core_frequency(args.frequency_file, use_vcgencmd))
             print(
                 "Current temperature: {}°C. Frequency: {}MHz".format(
-                    temps[-1], freqs[-1], end="\r"
+                    temps[-1], freqs[-1]
                 )
             )
         else:
-            print("Current temperature: {}°C".format(temps[-1]), end="\r")
+            print("Current temperature: {}°C".format(temps[-1]))
         # Choose the sample interval such that we have a respectable number of
         # data points
         t.join(2.0)
@@ -155,7 +155,7 @@ def plot(argv=None):
     data = [yaml.load(f, Loader=yaml.SafeLoader) for f in args.infiles]
 
     # sort the data such that the data series with the lowest terminal
-    # temperature is plotted last (and appears int he legend last)
+    # temperature is plotted last (and appears in the legend last)
     terminal_temps = [d["temperature"][-1] for d in data]
     order = [i[0] for i in sorted(enumerate(terminal_temps), key=lambda x: x[1])]
     # actually plot it
@@ -183,7 +183,7 @@ def plot(argv=None):
                     color="C1",
                 )
         except KeyError():
-            print("Source data does not contain cpu frequency data.")
+            print("Source data does not contain CPU frequency data.")
 
     if args.outfile is not None:
         plt.savefig(args.outfile, transparent=True, bbox_inches="tight", dpi=args.dpi)
@@ -229,7 +229,7 @@ def _get_parser_plot():
     parser.add_argument(
         "-f",
         "--frequency",
-        help="plot cpu core frequency (single input files only)",
+        help="plot CPU core frequency (single input files only)",
         action="store_true",
     )
     return parser

--- a/stressberry/cli.py
+++ b/stressberry/cli.py
@@ -57,6 +57,12 @@ def _get_parser_run():
         help="idle time in seconds at start and end of stress test (default: 150)",
     )
     parser.add_argument(
+        "--cooldown",
+        type=int,
+        default=60,
+        help="poll interval seconds to check for stable temperature (default: 60)",
+    )
+    parser.add_argument(
         "-c",
         "--cores",
         type=int,
@@ -80,7 +86,7 @@ def run(argv=None):
 
     # Cool down first
     print("Awaiting stable baseline temperature...")
-    cooldown(filename=args.temperature_file)
+    cooldown(interval=args.cooldown, filename=args.temperature_file)
 
     # Start the stress test in another thread
     t = threading.Thread(

--- a/stressberry/cli.py
+++ b/stressberry/cli.py
@@ -118,11 +118,11 @@ def run(argv=None):
             freqs.append(measure_core_frequency(args.frequency_file, use_vcgencmd))
             print(
                 "Current temperature: {}°C. Frequency: {}MHz".format(
-                    temps[-1], freqs[-1]
+                    temps[-1], freqs[-1], end="\r"
                 )
             )
         else:
-            print("Current temperature: {}°C".format(temps[-1]))
+            print("Current temperature: {}°C".format(temps[-1]), end="\r")
         # Choose the sample interval such that we have a respectable number of
         # data points
         t.join(2.0)

--- a/stressberry/cli.py
+++ b/stressberry/cli.py
@@ -186,7 +186,7 @@ def plot(argv=None):
             print("Source data does not contain cpu frequency data.")
 
     if args.outfile is not None:
-        plt.savefig(args.outfile, transparent=True, bbox_inches="tight")
+        plt.savefig(args.outfile, transparent=True, bbox_inches="tight", dpi=args.dpi)
     else:
         plt.show()
     return
@@ -218,6 +218,13 @@ def _get_parser_plot():
         nargs=2,
         default=None,
         help="limits for the temperature (default: data limits)",
+    )
+    parser.add_argument(
+        "-d",
+        "--dpi",
+        type=int,
+        default=None,
+        help="image resolution in dots per inch when written to file",
     )
     parser.add_argument(
         "-f",

--- a/stressberry/cli.py
+++ b/stressberry/cli.py
@@ -86,7 +86,7 @@ def _get_parser_run():
     parser.add_argument(
         "--disable-vcgencmd",
         help="Do not use Raspberry Pi vcgencmd to collect measurements, even if available. Use files instead.",
-        action="store_true"
+        action="store_true",
     )
     parser.add_argument("outfile", type=argparse.FileType("w"), help="output data file")
     return parser

--- a/stressberry/main.py
+++ b/stressberry/main.py
@@ -43,12 +43,9 @@ def cpu_core_count():
     return count
 
 
-def test(duration, cores):
+def test(stress_duration, idle_duration, cores):
     """Run stress test with 25% of test duration for idle before and after the stres
     """
-    stress_duration = 0.5 * duration
-    idle_duration = 0.25 * duration
-
     if cores is None:
         cores = cpu_core_count()
 

--- a/stressberry/main.py
+++ b/stressberry/main.py
@@ -44,7 +44,8 @@ def cpu_core_count():
 
 
 def test(stress_duration, idle_duration, cores):
-    """Run stress test with 25% of test duration for idle before and after the stres
+    """Run stress test for specified duration with specified idle times
+       at the start and end of the test.
     """
     if cores is None:
         cores = cpu_core_count()

--- a/stressberry/main.py
+++ b/stressberry/main.py
@@ -46,12 +46,12 @@ def measure_core_frequency(filename=None):
     """
     if filename is not None:
         with open(filename, "r") as f:
-            frequency = int(f.read()) / 1000
+            frequency = float(f.read()) / 1000
     else:
         # Only vcgencmd measure_clock arm is accurate on Raspberry Pi.
         # Per: https://www.raspberrypi.org/forums/viewtopic.php?f=63&t=219358&start=25
         out = subprocess.check_output(["vcgencmd", "measure_clock arm"]).decode("utf-8")
-        frequency = int(int(out.split("=")[1]) / 1000000)
+        frequency = float(out.split("=")[1]) / 1000000
     return frequency
 
 

--- a/stressberry/main.py
+++ b/stressberry/main.py
@@ -34,40 +34,13 @@ def measure_temp(filename="/sys/class/thermal/thermal_zone0/temp", use_vcgencmd=
     """Returns the core temperature in Celsius.
     """
     if use_vcgencmd:
-        # Using vcgencmd is specific to the raspberry pi
+        # Usign vcgencmd is specific to the raspberry pi
         out = subprocess.check_output(["vcgencmd", "measure_temp"]).decode("utf-8")
         temp = float(out.replace("temp=", "").replace("'C", ""))
     else:
         with open(filename, "r") as f:
             temp = float(f.read()) / 1000
     return temp
-
-
-def measure_core_frequency(
-    filename="/sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq", use_vcgencmd=False
-):
-    """Returns the CPU frequency in MHz
-    """
-    if use_vcgencmd:
-        # Only vcgencmd measure_clock arm is accurate on Raspberry Pi.
-        # Per: https://www.raspberrypi.org/forums/viewtopic.php?f=63&t=219358&start=25
-        # TODO: May also need to look at: vcgencmd get_throttled
-        out = subprocess.check_output(["vcgencmd", "measure_clock arm"]).decode("utf-8")
-        frequency = int(int(out.split("=")[1]) / 1000000)
-    else:
-        with open(filename, "r") as f:
-            frequency = int(f.read()) / 1000
-    return frequency
-
-
-def vcgencmd_avaialble():
-    """Returns true if vcgencmd is runnable, false otherwise
-    """
-    try:
-        subprocess.call(["vcgencmd"])
-        return True
-    except OSError:
-        return False
 
 
 def measure_core_frequency(

--- a/stressberry/main.py
+++ b/stressberry/main.py
@@ -17,7 +17,12 @@ def cooldown(interval=60, filename="/sys/class/thermal/thermal_zone0/temp"):
     while True:
         tme.sleep(interval)
         tmp = measure_temp(filename=filename)
-        print("Current temperature: {}°C - Previous temperature: {}°C".format(tmp, prev_tmp), end="\r")
+        print(
+            "Current temperature: {}°C - Previous temperature: {}°C".format(
+                tmp, prev_tmp
+            ),
+            end="\r",
+        )
         if abs(tmp - prev_tmp) < 0.2:
             break
         prev_tmp = tmp

--- a/stressberry/main.py
+++ b/stressberry/main.py
@@ -17,9 +17,11 @@ def cooldown(interval=60, filename="/sys/class/thermal/thermal_zone0/temp"):
     while True:
         tme.sleep(interval)
         tmp = measure_temp(filename=filename)
+        print("Current temperature: {}°C - Previous temperature: {}°C".format(tmp, prev_tmp), end="\r")
         if abs(tmp - prev_tmp) < 0.2:
             break
         prev_tmp = tmp
+        print("")  # Ensure next message starts on a new line.
     return tmp
 
 

--- a/stressberry/main.py
+++ b/stressberry/main.py
@@ -70,22 +70,15 @@ def vcgencmd_avaialble():
         return False
 
 
-def cpu_core_count():
-    """Returns the number of CPU cores
-    """
-    count = cpu_count()
-    return count
-
-
 def test(stress_duration, idle_duration, cores):
     """Run stress test for specified duration with specified idle times
        at the start and end of the test.
     """
     if cores is None:
-        cores = cpu_core_count()
+        cores = cpu_count()
 
     print(
-        "Preparing to stress: [{}] CPU Cores for [{}] seconds".format(
+        "Preparing to stress [{}] CPU Cores for [{}] seconds".format(
             cores, stress_duration
         )
     )

--- a/stressberry/main.py
+++ b/stressberry/main.py
@@ -20,13 +20,11 @@ def cooldown(interval=60, filename="/sys/class/thermal/thermal_zone0/temp"):
         print(
             "Current temperature: {}°C - Previous temperature: {}°C".format(
                 tmp, prev_tmp
-            ),
-            end="\r",
+            )
         )
         if abs(tmp - prev_tmp) < 0.2:
             break
         prev_tmp = tmp
-        print("")  # Ensure next message starts on a new line.
     return tmp
 
 
@@ -34,7 +32,7 @@ def measure_temp(filename="/sys/class/thermal/thermal_zone0/temp", use_vcgencmd=
     """Returns the core temperature in Celsius.
     """
     if use_vcgencmd:
-        # Usign vcgencmd is specific to the raspberry pi
+        # Using vcgencmd is specific to the raspberry pi
         out = subprocess.check_output(["vcgencmd", "measure_temp"]).decode("utf-8")
         temp = float(out.replace("temp=", "").replace("'C", ""))
     else:
@@ -61,7 +59,7 @@ def measure_core_frequency(
 
 
 def vcgencmd_avaialble():
-    """Returns true if vcgencmd is runable, false otherwise
+    """Returns true if vcgencmd is runnable, false otherwise
     """
     try:
         subprocess.call(["vcgencmd"])

--- a/stressberry/main.py
+++ b/stressberry/main.py
@@ -34,13 +34,40 @@ def measure_temp(filename="/sys/class/thermal/thermal_zone0/temp", use_vcgencmd=
     """Returns the core temperature in Celsius.
     """
     if use_vcgencmd:
-        # Usign vcgencmd is specific to the raspberry pi
+        # Using vcgencmd is specific to the raspberry pi
         out = subprocess.check_output(["vcgencmd", "measure_temp"]).decode("utf-8")
         temp = float(out.replace("temp=", "").replace("'C", ""))
     else:
         with open(filename, "r") as f:
             temp = float(f.read()) / 1000
     return temp
+
+
+def measure_core_frequency(
+    filename="/sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq", use_vcgencmd=False
+):
+    """Returns the CPU frequency in MHz
+    """
+    if use_vcgencmd:
+        # Only vcgencmd measure_clock arm is accurate on Raspberry Pi.
+        # Per: https://www.raspberrypi.org/forums/viewtopic.php?f=63&t=219358&start=25
+        # TODO: May also need to look at: vcgencmd get_throttled
+        out = subprocess.check_output(["vcgencmd", "measure_clock arm"]).decode("utf-8")
+        frequency = int(int(out.split("=")[1]) / 1000000)
+    else:
+        with open(filename, "r") as f:
+            frequency = int(f.read()) / 1000
+    return frequency
+
+
+def vcgencmd_avaialble():
+    """Returns true if vcgencmd is runnable, false otherwise
+    """
+    try:
+        subprocess.call(["vcgencmd"])
+        return True
+    except OSError:
+        return False
 
 
 def measure_core_frequency(

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -13,7 +13,9 @@ def test_run():
         f.write("1500000")
 
     outfile = tempfile.NamedTemporaryFile().name
-    stressberry.cli.run([outfile, "-t", temperature_file, "-f", frequency_file, "-d", "12", "-i", "3"])
+    stressberry.cli.run(
+        [outfile, "-t", temperature_file, "-f", frequency_file, "-d", "12", "-i", "3"]
+    )
 
     stressberry.cli.plot([outfile])
     return

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -20,10 +20,37 @@ def test_run():
 
     outfile = tempfile.NamedTemporaryFile().name
     stressberry.cli.run(
-        [outfile, "-t", temperature_file, "-f", frequency_file, "-d", "12", "-i", "2", "--cooldown", "1"]
+        [
+            outfile,
+            "-t",
+            temperature_file,
+            "-f",
+            frequency_file,
+            "-d",
+            "12",
+            "-i",
+            "2",
+            "--cooldown",
+            "1",
+        ]
     )
 
-    stressberry.cli.plot([outfile, "-f", "--temp-lims", "20", "90", "--freq-lims", "500", "2000"])
+    stressberry.cli.plot(
+        [outfile, "-f", "--temp-lims", "20", "90", "--freq-lims", "500", "2000"]
+    )
     plotoutfile = tempfile.NamedTemporaryFile().name
-    stressberry.cli.plot([outfile, "-f", "--temp-lims", "20", "90", "--freq-lims", "500", "2000", "-o", plotoutfile])
+    stressberry.cli.plot(
+        [
+            outfile,
+            "-f",
+            "--temp-lims",
+            "20",
+            "90",
+            "--freq-lims",
+            "500",
+            "2000",
+            "-o",
+            plotoutfile,
+        ]
+    )
     return

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -8,8 +8,12 @@ def test_run():
     with open(temperature_file, "w") as f:
         f.write("12345")
 
+    frequency_file = tempfile.NamedTemporaryFile().name
+    with open(frequency_file, "w") as f:
+        f.write("1500000")
+
     outfile = tempfile.NamedTemporaryFile().name
-    stressberry.cli.run([outfile, "-t", temperature_file, "-d", "12"])
+    stressberry.cli.run([outfile, "-t", temperature_file, "-f", frequency_file, "-d", "12", "-i", "3"])
 
     stressberry.cli.plot([outfile])
     return

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -17,5 +17,5 @@ def test_run():
         [outfile, "-t", temperature_file, "-f", frequency_file, "-d", "12", "-i", "3"]
     )
 
-    stressberry.cli.plot([outfile])
+    stressberry.cli.plot([outfile, "-f"])
     return

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -12,17 +12,18 @@ def test_run():
     with open(frequency_file, "w") as f:
         f.write("1500000")
 
-    outfile1 = tempfile.NamedTemporaryFile().name
+    # TODO: Need to mock call to subprocess.check_output
+    # outfile1 = tempfile.NamedTemporaryFile().name
+    # stressberry.cli.run(
+    #     [outfile1, "-d", "12", "-i", "2", "--cooldown", "1"]
+    # )
+
+    outfile = tempfile.NamedTemporaryFile().name
     stressberry.cli.run(
-        [outfile1, "-d", "12", "-i", "2", "--cooldown", "1"]
-    )
-    
-    outfile2 = tempfile.NamedTemporaryFile().name
-    stressberry.cli.run(
-        [outfile2, "-t", temperature_file, "-f", frequency_file, "-d", "12", "-i", "2", "--cooldown", "1"]
+        [outfile, "-t", temperature_file, "-f", frequency_file, "-d", "12", "-i", "2", "--cooldown", "1"]
     )
 
-    stressberry.cli.plot([outfile1, "-f", "--temp-lims", "20", "90", "--freq-lims", "500", "2000"])
+    stressberry.cli.plot([outfile, "-f", "--temp-lims", "20", "90", "--freq-lims", "500", "2000"])
     plotoutfile = tempfile.NamedTemporaryFile().name
-    stressberry.cli.plot([outfile2, "-f", "--temp-lims", "20", "90", "--freq-lims", "500", "2000", "-o", plotoutfile])
+    stressberry.cli.plot([outfile, "-f", "--temp-lims", "20", "90", "--freq-lims", "500", "2000", "-o", plotoutfile])
     return

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -12,10 +12,17 @@ def test_run():
     with open(frequency_file, "w") as f:
         f.write("1500000")
 
-    outfile = tempfile.NamedTemporaryFile().name
+    outfile1 = tempfile.NamedTemporaryFile().name
     stressberry.cli.run(
-        [outfile, "-t", temperature_file, "-f", frequency_file, "-d", "12", "-i", "3"]
+        [outfile1, "-d", "12", "-i", "2", "--cooldown", "1"]
+    )
+    
+    outfile2 = tempfile.NamedTemporaryFile().name
+    stressberry.cli.run(
+        [outfile2, "-t", temperature_file, "-f", frequency_file, "-d", "12", "-i", "2", "--cooldown", "1"]
     )
 
-    stressberry.cli.plot([outfile, "-f"])
+    stressberry.cli.plot([outfile1, "-f", "--temp-lims", "20", "90", "--freq-lims", "500", "2000"])
+    plotoutfile = tempfile.NamedTemporaryFile().name
+    stressberry.cli.plot([outfile2, "-f", "--temp-lims", "20", "90", "--freq-lims", "500", "2000", "-o", plotoutfile])
     return


### PR DESCRIPTION
I expect this PR to be a bit more contentious than the last one, and arguably could be broken into multiple PRs. 

**Data recording**
* Add recording of core clock frequency, using vcgencmd (if available) with fall back to a file (configurable location).  Only vcgencmd accurately reports the core clock speed when being throttled.
* Use vcgencmd if available for temperature collection. This is stressberry afterall so should be aimed at the Pi. Fallback to file if vcgencmd is not available. Argument available to force file to be used instead.

**Data Plotting**
* Add ability to plot frequency on a secondary axis. Single files only.
* Frequency axis limits configurable
* Additional graph output options, default behaviour remains unchanged:
  * Image Transparency
  * Image resolution (dpi)
  * Legend visibility
  * Line width

