### PR TITLE
Remove --user reference installing module

### DIFF
--- a/stressberry/main.py
+++ b/stressberry/main.py
@@ -59,7 +59,7 @@ def measure_ambient_temperature(sensor_type="2302", pin="23"):
     try:
         import Adafruit_DHT  # Late import so that library is only needed if requested
     except ImportError as e:
-        print("Install adafruit_dht python module: pip --user install Adafruit_DHT")
+        print("Install adafruit_dht python module: pip install Adafruit_DHT")
         raise e
 
     sensor_map = {


### PR DESCRIPTION
#65 Removed --user from readme, but not from instructions presented to the user when the Adaftruit_DHT module wasn't found.