### PR TITLE
convert to matplotx from dufte, fixes #118

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
     steps:
     - uses: actions/setup-python@v2
       with:

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,6 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -27,11 +26,11 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    dufte
     importlib_metadata;python_version<"3.8"
     matplotlib
+    matplotx
     pyyaml
-python_requires = >=3.6
+python_requires = >=3.7
 
 [options.entry_points]
 console_scripts =

--- a/stressberry/cli/plot.py
+++ b/stressberry/cli/plot.py
@@ -6,10 +6,10 @@ from .helpers import _get_version_text
 
 
 def plot(argv=None):
-    import dufte
+    import matplotx
     import matplotlib.pyplot as plt
 
-    plt.style.use(dufte.style)
+    plt.style.use(matplotx.styles.dufte)
 
     parser = _get_parser_plot()
     args = parser.parse_args(argv)
@@ -29,7 +29,7 @@ def plot(argv=None):
 
         plt.plot(d["time"], temperature_data, label=d["name"])
 
-    dufte.legend()
+    matplotx.line_labels()
 
     if args.delta_t:
         plot_yaxis_label = "Δ temperature [°C over ambient]"


### PR DESCRIPTION
I am not python-savvy by any means but I think this does the job.  Build environment for me was having `python-matplotx` substituting in for `python-dufte` (all other depds/makedeps on board).

* graphs a file correctly ie `stressberry-plot -o caseless2.png -f -l 200 2200 -t 20 90 fan.dat` gives the expected plot.
* passes tests
```
% mkdir -p temp
% site_packages=$(python -c "import site; print(site.getsitepackages()[0])")
% python -m install --optimize=1 --destdir=temp dist/*.whl
%PATH="$PWD/temp/usr/bin:$PATH" PYTHONPATH="$PWD/temp/$site_packages" python -m pytest
['/usr/lib/python3.9/site-packages/install/_vendor/installer/src', '/scratch/stressberry/src/stressberry-0.3.3', '/usr/lib/python39.zip', '/usr/lib/python3.9', '/usr/lib/python3.9/lib-dynload', '/usr/lib/python3.9/site-packages']
Listing '.install-cache/pkg'...
Listing '.install-cache/pkg/stressberry'...
Compiling '.install-cache/pkg/stressberry/__about__.py'...
Compiling '.install-cache/pkg/stressberry/__init__.py'...
Listing '.install-cache/pkg/stressberry/cli'...
Compiling '.install-cache/pkg/stressberry/cli/__init__.py'...
Compiling '.install-cache/pkg/stressberry/cli/helpers.py'...
Compiling '.install-cache/pkg/stressberry/cli/plot.py'...
Compiling '.install-cache/pkg/stressberry/cli/run.py'...
Compiling '.install-cache/pkg/stressberry/main.py'...
Listing '.install-cache/pkg/stressberry-0.3.3.dist-info'...
===================================================== test session starts ======================================================
platform linux -- Python 3.9.9, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
rootdir: /scratch/stressberry/src/stressberry-0.3.3
collected 2 items                                                                                                              

test/test_cli.py .                                                                                                       [ 50%]
test/test_stressberry.py .                                                                                               [100%]

====================================================== 2 passed in 27.55s ======================================================
```